### PR TITLE
FP8 Training Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 wandb/
 src/__pycache__/
 demo/
+fla/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pytorch-lightning==1.9.5
+pytorch-lightning==2.4.0
 bitsandbytes
 deepspeed
 einops
-triton==2.2.0
+triton==3.0.0
 rwkv-fla

--- a/scripts/run_lora_fp8.sh
+++ b/scripts/run_lora_fp8.sh
@@ -1,0 +1,26 @@
+load_model='/home/client/Projects/RWKV-LM-RLHF/v6/models/RWKV-x060-Jpn-7B-20240816-ctx4096.pth'
+proj_dir='/home/client/Projects/RWKV/test'
+data_file='/home/client/Projects/RWKV/RWKV5-LM-LoRA/RWKV-v6/dataset/test'
+
+n_layer=32
+n_embd=4096
+
+micro_bsz=4
+epoch_save=1
+epoch_steps=200 #6171
+ctx_len=1024
+
+lora_config='{"lora_load":"","lora_r":32,"lora_alpha":32,"lora_dropout":0.0,"lora_parts":"att,ffn"}'
+
+
+python train.py --load_model $load_model \
+--proj_dir $proj_dir --data_file $data_file \
+--data_type binidx --vocab_size 65536 \
+--ctx_len $ctx_len --epoch_steps $epoch_steps --epoch_count 1 --epoch_begin 0 --epoch_save $epoch_save --micro_bsz $micro_bsz \
+--n_layer $n_layer --n_embd $n_embd \
+--pre_ffn 0 --head_qk 0 --lr_init 2e-5 --lr_final 2e-5 --warmup_steps 0 --beta1 0.9 --beta2 0.99 --adam_eps 1e-8 \
+--accelerator gpu --devices 1 --precision bf16 --strategy deepspeed_stage_1 --grad_cp 1 \
+--my_testing "x060" \
+--peft lora --lora_config $lora_config --train_parts [] \
+--wandb "RWKV-PEFT FP8 Test LoRA" \
+--quant "fp8" 

--- a/scripts/run_pissa_fp8.sh
+++ b/scripts/run_pissa_fp8.sh
@@ -1,0 +1,26 @@
+load_model='/home/client/Projects/RWKV-LM-RLHF/v6/models/RWKV-x060-Jpn-7B-20240816-ctx4096.pth'
+proj_dir='/home/client/Projects/RWKV/test'
+data_file='/home/client/Projects/RWKV/RWKV5-LM-LoRA/RWKV-v6/dataset/test'
+
+n_layer=32
+n_embd=4096
+
+micro_bsz=4
+epoch_save=1
+epoch_steps=200 #6171
+ctx_len=1024
+
+pissa_config='{"pissa_load":"","pissa_init":"","pissa_r":32,"svd_niter":4,"pissa_parts":"att,ffn"}'
+
+
+python train.py --load_model $load_model \
+--proj_dir $proj_dir --data_file $data_file \
+--data_type binidx --vocab_size 65536 \
+--ctx_len $ctx_len --epoch_steps $epoch_steps --epoch_count 1 --epoch_begin 0 --epoch_save $epoch_save --micro_bsz $micro_bsz \
+--n_layer $n_layer --n_embd $n_embd \
+--pre_ffn 0 --head_qk 0 --lr_init 2e-5 --lr_final 2e-5 --warmup_steps 0 --beta1 0.9 --beta2 0.99 --adam_eps 1e-8 \
+--accelerator gpu --devices 1 --precision bf16 --strategy deepspeed_stage_1 --grad_cp 1 \
+--my_testing "x060" \
+--peft pissa --pissa_config $pissa_config --train_parts [] \
+--wandb "RWKV-PEFT FP8 PISSA Test" \
+--quant "fp8"

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -102,9 +102,9 @@ class MyDataset(Dataset):
 
     def __getitem__(self, idx):
         args = self.args
-        rank = self.global_rank
-        epoch = self.real_epoch
-        world_size = self.world_size
+        rank = 0#self.trainer.global_rank temporary 0
+        epoch = 0#self.real_epoch temporary 0
+        world_size = 0#self.world_size temporart 0
         # print(f"epoch {epoch} idx {idx} rank {rank}/{world_size}")
         devices = int(args.devices)
         if devices>1:


### PR DESCRIPTION
Gooday :)

I have implemented FP8 support for RWKV-PEFT.

In LoRA and PISSA, fp8matmul is used for Forward operations.
I hope this can be used as a reference.

There is no need to approve the pull request.

It requires Torch2.4+, Pytorch-lightning=2.4.0, and triton=3.0.0,
which are not recommended environment settings.

In x060 7B @ RTX4090
ctx1024, bsz=4

PISSA
NF4 : 2.02kt/s
INT8: 1.84kt/s
FP8 : 2.50kt/s

LoRA
NF4 : 2.01kt/s
INT8: 1.85kt/s
FP8 : 2.49kt/s

It seems to be 35% faster than Bitsandbytes
Loss is roughly the same as Int8