### PR TITLE
fix time mix bugs

### DIFF
--- a/rwkvt/rwkv7/att.py
+++ b/rwkvt/rwkv7/att.py
@@ -240,7 +240,7 @@ class RWKV_Tmix_x070_infctx(RWKV_Tmix_x070):
 
         #print(f'x shape = {x.shape}')
 
-        shift_state = x[:,-1,:]
+        shift_state = x[:,0,:]
 
         r = self.receptance(xr)
         w = -F.softplus(-(self.w0 + torch.tanh(xw @ self.w1) @ self.w2)) - 0.5 # soft-clamp to (-inf, -0.5)


### PR DESCRIPTION
shift state保存的应该是上一时刻滑动窗口丢失掉的序列x值，应为x[0]，而不是x[-1]（大概？）
不过，使用x[-1]训练后的模型似乎也可以正常工作，不得不说语言模型确实很神奇x